### PR TITLE
Feature/luc/stack jagged

### DIFF
--- a/spellbook/data_formatting/conduit/python/collector.py
+++ b/spellbook/data_formatting/conduit/python/collector.py
@@ -1,28 +1,34 @@
 from __future__ import print_function
 
 import argparse
-from itertools import zip_longest
 import json
 import sys
+from itertools import zip_longest
 from uuid import uuid4
 
+from spellbook.data_formatting.conduit.python import conduit_bundler as cb
 from spellbook.utils import prep_argparse
 
 
-import conduit
-from . import conduit_bundler as cb
+WARN = ""
+try:
+    import conduit
+except:
+    WARN = "\nWARNING: conduit not found."
 
 
 def grouper(iterable, n):
     args = [iter(iterable)] * n
     return zip_longest(*args, fillvalue=None)
 
+
 def savename(file_no, args):
     if args.chunk_size:
-        base, ext = args.outfile.split('.')
+        base, ext = args.outfile.split(".")
         name = f"{base}_{file_no:03}.{ext}"
         return name
     return args.outfile
+
 
 def process_args(args):
 
@@ -32,7 +38,6 @@ def process_args(args):
         chunk_size = nfiles
     else:
         chunk_size = args.chunk_size
-
 
     fileno = 0
     results = []
@@ -57,24 +62,36 @@ def process_args(args):
             except:
                 print("Unable to load " + path)
 
-        cb.dump_node(result, savename(fileno,args))
+        cb.dump_node(result, savename(fileno, args))
         fileno = fileno + 1
 
+
 def setup_argparse(parent_parser=None, the_subparser=None):
-    description = "Convert a list of conduit-readable files into a single big conduit node. Simple append, so nodes that already exist will get a name change to conflict-uuid"
+    description = "Convert a list of conduit-readable files into a single big conduit node. Simple append, so nodes that already exist will get a name change to conflict-uuid{}".format(
+        WARN
+    )
     parser, subparsers = prep_argparse(description, parent_parser, the_subparser)
 
     # spellbook collect
-    collect = subparsers.add_parser(
-        "collect",
-        help=description,
-    )
+    collect = subparsers.add_parser("collect", help=description)
     collect.set_defaults(func=process_args)
     collect.add_argument(
-        "-infiles", help="whitespace separated list of files to collect", default="", nargs='+'
+        "-infiles",
+        help="whitespace separated list of files to collect",
+        default="",
+        nargs="+",
     )
-    collect.add_argument("-outfile", help="aggregated file root. If chunking will insert _n before extension", default="results.hdf5")
-    collect.add_argument("-chunk_size", help="number of files to chunk together. Default (None): don't chunk", default=None, type=int)
+    collect.add_argument(
+        "-outfile",
+        help="aggregated file root. If chunking will insert _n before extension",
+        default="results.hdf5",
+    )
+    collect.add_argument(
+        "-chunk_size",
+        help="number of files to chunk together. Default (None): don't chunk",
+        default=None,
+        type=int,
+    )
     return parser
 
 

--- a/spellbook/data_formatting/stack_npz.py
+++ b/spellbook/data_formatting/stack_npz.py
@@ -3,6 +3,7 @@
 import argparse
 import os
 import sys
+import shutil
 
 import numpy as np
 
@@ -46,7 +47,8 @@ class Stacker(object):
         self.dout = {}
 
     def run(self, target, source, force=False):
-        print("hadd Target file: {0}".format(target))
+
+        print("Target file: {0}".format(target))
 
         if not force:
             if os.path.isfile(target):
@@ -56,6 +58,14 @@ class Stacker(object):
                     )
                 )
                 print('Pass "-f" argument to force re-creation of output file.')
+                return
+
+        n_source = len(source)
+        if n_source == 1:
+            print("Only one source file given! Not stacking, just doing a copy.")
+            shutil.copy(source[0], target)
+            print("DONE")
+            return
 
         # Loop over the source files
         for i, s in enumerate(source):


### PR DESCRIPTION
Addresses error in stack_npz from jagged PR when given only one file. Faster too, by just doing a copy. Also if file exists, exits right away instead of going through and loading/stacking everything.