### PR TITLE
Fix optimization import, update version to 0.7.2, update changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to Merlin Spellbook will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2]
+
+### Fixed
+- Add missing __init__.py to optimization module.
+
+### Changed
+- Remove .keepme file in optimization module.
+
 ## [0.7.1]
 
 ### Fixed

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin-Spellbook, Version: 0.7.1.
+# This file is part of Merlin-Spellbook, Version: 0.7.2.
 #
 # For details, see https://github.com/LLNL/merlin-spellbook.
 #

--- a/spellbook/__init__.py
+++ b/spellbook/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "0.7.1"
+__version__ = "0.7.2"
 
 VERSION = __version__

--- a/spellbook/data_formatting/conduit/python/conduit_bundler.py
+++ b/spellbook/data_formatting/conduit/python/conduit_bundler.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-<PENDING>
 # All rights reserved.
-# This file is part of merlin-spellbook, Version: 0.7.1.
+# This file is part of merlin-spellbook, Version: 0.7.2.
 #
 # For details, see https://github.com/LLNL/merlin-spellbook.
 #

--- a/spellbook/log_formatter.py
+++ b/spellbook/log_formatter.py
@@ -6,7 +6,7 @@
 #
 # LLNL-CODE-797170
 # All rights reserved.
-# This file is part of Merlin Spellbook, Version: 0.7.1.
+# This file is part of Merlin Spellbook, Version: 0.7.2.
 #
 # For details, see https://github.com/LLNL/merlin.
 #


### PR DESCRIPTION
The command, `spellbook make-barrier-cost`, runs into an import error because the module optimization was missing an `__init__.py`. Adding `__init__.py` allows the make-barrier-cost function to import qoi from the optimization module.
