### PR TITLE
Included -round option in make-samples

### DIFF
--- a/spellbook/commands/make-samples.py
+++ b/spellbook/commands/make-samples.py
@@ -9,8 +9,20 @@ import click
     type=int,
     help="random number seed for generating samples",
 )
-@click.option("-n", required=False, default=100, type=int, help="number of samples")
-@click.option("-dims", required=False, default=2, type=int, help="number of dimensions")
+@click.option(
+    "-n",
+    required=False,
+    default=100,
+    type=int,
+    help="number of samples"
+)
+@click.option(
+    "-dims",
+    required=False,
+    default=2,
+    type=int,
+    help="number of dimensions"
+)
 @click.option(
     "-sample_type",
     required=False,
@@ -72,6 +84,19 @@ import click
     )
 )
 @click.option(
+    "-repeat",
+    required=False,
+    default=None,
+    type=str,
+    help=(
+        "enable to repeat the generated samples by a given amounts. "
+        "Optionally, can fix the seed by specifying which column of the "
+        "PARAMETERS the seed value is located. Format is '[5, -1]' to specify "
+        "five repeats and the seed column being located at the last column. "
+        "Can also only specify one value."
+    )
+)
+@click.option(
     "--hard-bounds",
     is_flag=True,
     required=False,
@@ -87,6 +112,7 @@ def cli(
     scale,
     scale_factor,
     round,
+    repeat,
     outfile,
     x0,
     x1,
@@ -107,6 +133,7 @@ def cli(
         scale,
         scale_factor,
         round,
+        repeat,
         outfile,
         x0,
         x1,

--- a/spellbook/commands/make-samples.py
+++ b/spellbook/commands/make-samples.py
@@ -61,6 +61,17 @@ import click
     help="number of samples along a line between x0 and x1",
 )
 @click.option(
+    "-round",
+    required=False,
+    default=None,
+    type=str,
+    help=(
+        "will round generated samples with options of False (no rounding), "
+        "round (nearest integer), floor, or ceil. Format is '[False, ceil, "
+        "ceil]'."
+    )
+)
+@click.option(
     "--hard-bounds",
     is_flag=True,
     required=False,
@@ -75,6 +86,7 @@ def cli(
     sample_type,
     scale,
     scale_factor,
+    round,
     outfile,
     x0,
     x1,
@@ -94,6 +106,7 @@ def cli(
         sample_type,
         scale,
         scale_factor,
+        round,
         outfile,
         x0,
         x1,

--- a/spellbook/sampling/make_samples.py
+++ b/spellbook/sampling/make_samples.py
@@ -160,12 +160,9 @@ class MakeSamples(CliCommand):
             for e, r in enumerate(round):
                 if r.lower() not in [ v.lower() for v in values]:
                     raise ValueError(f"{r} is not an option. Must use {values}.")
-                elif r == 'round':
-                    x[:,e] = np.round(x[:,e].astype('float')).astype('int')
-                elif r == 'floor':
-                    x[:,e] = np.floor(x[:,e].astype('float')).astype('int')
-                elif r == 'ceil':
-                    x[:,e] = np.ceil(x[:,e].astype('float')).astype('int')
+                if r != 'False':
+                    func = getattr(np, r)
+                    x[:,e] = func(x[:,e].astype('float')).astype('int')
 
         # add x0
         if x0 is not None:

--- a/spellbook/sampling/make_samples.py
+++ b/spellbook/sampling/make_samples.py
@@ -160,7 +160,7 @@ class MakeSamples(CliCommand):
             for e, r in enumerate(round):
                 if r.lower() not in [ v.lower() for v in values]:
                     raise ValueError(f"{r} is not an option. Must use {values}.")
-                if r != 'False':
+                if r.lower() != 'false':
                     func = getattr(np, r)
                     x[:,e] = func(x[:,e].astype('float')).astype('int')
 

--- a/spellbook/sampling/make_samples.py
+++ b/spellbook/sampling/make_samples.py
@@ -78,6 +78,10 @@ def process_scale(scale):
         processed = np.array(raw, dtype=float).tolist()
         return processed
 
+def process_round(round):
+    if round is not None:
+        return round.strip('[|]').replace(" ","").split(",")
+
 
 class MakeSamples(CliCommand):
     def get_samples(self, sample_type, n_samples, n_dims, seed):
@@ -112,6 +116,7 @@ class MakeSamples(CliCommand):
         sample_type,
         scale,
         scale_factor,
+        round,
         outfile,
         x0,
         x1,
@@ -143,6 +148,23 @@ class MakeSamples(CliCommand):
 
         # scale the whole box
         x = scale_factor * x
+
+        if round is not None:
+            # round the samples
+            round = process_round(round)
+            values = ['False', 'round', 'floor', 'ceil']
+            # check that the array sizes are the same
+            if len(round) != n_dims:
+                raise ValueError("length of -round must equal value of -dims.")
+            for e, r in enumerate(round):
+                if r.lower() not in [ v.lower for v in values]:
+                    raise ValueError(f"{r} is not an option. Must use {values}.")
+                elif r == 'round':
+                    x[:,e] = np.round(x[:,e])
+                elif r == 'floor':
+                    x[:,e] = np.floor(x[:,e])
+                elif r == 'ceil':
+                    x[:,e] = np.ceil(x[:,e])
 
         # add x0
         if x0 is not None:

--- a/spellbook/sampling/make_samples.py
+++ b/spellbook/sampling/make_samples.py
@@ -78,12 +78,14 @@ def process_scale(scale):
         processed = np.array(raw, dtype=float).tolist()
         return processed
 
+
 def process_round(round):
     if round is not None:
-        return round.strip('[|]').replace(" ","").split(",")
+        return round.strip('[|]').replace(" ", "").split(",")
+
 
 def process_repeat(repeat):
-    return repeat.strip('[|]').replace(" ","").split(",")
+    return repeat.strip('[|]').replace(" ", "").split(",")
 
 
 class MakeSamples(CliCommand):
@@ -111,6 +113,61 @@ class MakeSamples(CliCommand):
 
         return x
 
+    def apply_scale(self, x, scales):
+        if scales is not None:
+            limits = []
+            do_log = []
+            for scale in scales:
+                limits.append((scale[0], scale[1]))
+                if len(scale) < 3:
+                    scale.append("linear")
+                if scale[2] == "log":
+                    do_log.append(True)
+                else:
+                    do_log.append(False)
+            x = scale_samples(x, limits, do_log=do_log)
+        return x
+
+    def apply_rounding(self, x, round):
+        if round is not None:
+            x = x.astype('object')
+            # round the samples
+            round = process_round(round)
+            values = ['False', 'round', 'floor', 'ceil']
+            # check that the array sizes are the same
+            if len(round) != self.n_dims:
+                raise ValueError("length of -round must equal value of -dims.")
+            for e, r in enumerate(round):
+                if r.lower() not in [v.lower() for v in values]:
+                    raise ValueError(f"{r} is not an option. Must use {values}.")
+                if r.lower() != 'false':
+                    func = getattr(np, r)
+                    x[:, e] = func(x[:, e].astype('float')).astype('int')
+        return x
+
+    def apply_repeat(self, x, repeat):
+        if repeat is not None:
+            repeat = process_repeat(repeat)
+            # Check that the values are integers
+            try:
+                repeat = [int(r) for r in repeat]
+            except ValueError:
+                raise ValueError(
+                    f"one of the values in {repeat} is not in integer format."
+                )
+            num_repeat = repeat[0]
+            x = np.repeat(x, num_repeat, axis=0)
+            if len(repeat) == 2:
+                seed_col = repeat[1]
+                # Generate and fix seed value to specified column
+                s = np.random.rand(self.n_samples) * 10**6
+                s = np.round(s).astype('int').tolist()
+                s = s * num_repeat
+                s = np.array(s)
+                # Insert into array for the specified column
+                x[:, seed_col] = s[:]
+        return x
+
     def run(
         self,
         seed,
@@ -128,66 +185,22 @@ class MakeSamples(CliCommand):
         hard_bounds,
     ):
         np.random.seed(seed)
-        n_samples = n
-        n_dims = dims
+        self.n_samples = n
+        self.n_dims = dims
         hard_bounds = hard_bounds
         sample_type = sample_type
 
-        x = self.get_samples(sample_type, n_samples, n_dims, seed)
+        x = self.get_samples(sample_type, self.n_samples, self.n_dims, seed)
 
         scales = process_scale(scale)
 
-        if scales is not None:
-            limits = []
-            do_log = []
-            for scale in scales:
-                limits.append((scale[0], scale[1]))
-                if len(scale) < 3:
-                    scale.append("linear")
-                if scale[2] == "log":
-                    do_log.append(True)
-                else:
-                    do_log.append(False)
-            x = scale_samples(x, limits, do_log=do_log)
+        x = self.apply_scale(x, scales)
 
         # scale the whole box
         x = scale_factor * x
 
-        if round is not None:
-            x = x.astype('object')
-            # round the samples
-            round = process_round(round)
-            values = ['False', 'round', 'floor', 'ceil']
-            # check that the array sizes are the same
-            if len(round) != n_dims:
-                raise ValueError("length of -round must equal value of -dims.")
-            for e, r in enumerate(round):
-                if r.lower() not in [ v.lower() for v in values]:
-                    raise ValueError(f"{r} is not an option. Must use {values}.")
-                if r.lower() != 'false':
-                    func = getattr(np, r)
-                    x[:,e] = func(x[:,e].astype('float')).astype('int')
-
-        if repeat is not None:
-            repeat = process_repeat(repeat)
-            # Check that the values are integers
-            try:
-                repeat = [int(r) for r in repeat]
-            except:
-                raise ValueError(
-                    f"one of the values in {repeat} is not in integer format."
-                )
-            num_repeat = repeat[0]
-            x = np.repeat(x, num_repeat, axis=0)
-            if len(repeat) == 2:
-                seed_col = repeat[1]
-                # Generate and fix seed value to specified column
-                s = np.random.rand(n_samples) * 10**6
-                s = np.round(s).astype('int').tolist()
-                s = s * num_repeat
-                s = np.array(s)
-                # Insert into array for the specified column
-                x[:, seed_col] = s[:]
+        x = self.apply_rounding(x, round)
+        x = self.apply_repeat(x, repeat)
 
         # add x0
         if x0 is not None:

--- a/spellbook/sampling/make_samples.py
+++ b/spellbook/sampling/make_samples.py
@@ -157,7 +157,7 @@ class MakeSamples(CliCommand):
             if len(round) != n_dims:
                 raise ValueError("length of -round must equal value of -dims.")
             for e, r in enumerate(round):
-                if r.lower() not in [ v.lower for v in values]:
+                if r.lower() not in [ v.lower() for v in values]:
                     raise ValueError(f"{r} is not an option. Must use {values}.")
                 elif r == 'round':
                     x[:,e] = np.round(x[:,e])

--- a/spellbook/sampling/make_samples.py
+++ b/spellbook/sampling/make_samples.py
@@ -82,6 +82,9 @@ def process_round(round):
     if round is not None:
         return round.strip('[|]').replace(" ","").split(",")
 
+def process_repeat(repeat):
+    return repeat.strip('[|]').replace(" ","").split(",")
+
 
 class MakeSamples(CliCommand):
     def get_samples(self, sample_type, n_samples, n_dims, seed):
@@ -117,6 +120,7 @@ class MakeSamples(CliCommand):
         scale,
         scale_factor,
         round,
+        repeat,
         outfile,
         x0,
         x1,
@@ -163,6 +167,27 @@ class MakeSamples(CliCommand):
                 if r.lower() != 'false':
                     func = getattr(np, r)
                     x[:,e] = func(x[:,e].astype('float')).astype('int')
+
+        if repeat is not None:
+            repeat = process_repeat(repeat)
+            # Check that the values are integers
+            try:
+                repeat = [int(r) for r in repeat]
+            except:
+                raise ValueError(
+                    f"one of the values in {repeat} is not in integer format."
+                )
+            num_repeat = repeat[0]
+            x = np.repeat(x, num_repeat, axis=0)
+            if len(repeat) == 2:
+                seed_col = repeat[1]
+                # Generate and fix seed value to specified column
+                s = np.random.rand(n_samples) * 10**6
+                s = np.round(s).astype('int').tolist()
+                s = s * num_repeat
+                s = np.array(s)
+                # Insert into array for the specified column
+                x[:, seed_col] = s[:]
 
         # add x0
         if x0 is not None:

--- a/spellbook/sampling/make_samples.py
+++ b/spellbook/sampling/make_samples.py
@@ -150,6 +150,7 @@ class MakeSamples(CliCommand):
         x = scale_factor * x
 
         if round is not None:
+            x = x.astype('object')
             # round the samples
             round = process_round(round)
             values = ['False', 'round', 'floor', 'ceil']
@@ -160,11 +161,11 @@ class MakeSamples(CliCommand):
                 if r.lower() not in [ v.lower() for v in values]:
                     raise ValueError(f"{r} is not an option. Must use {values}.")
                 elif r == 'round':
-                    x[:,e] = np.round(x[:,e])
+                    x[:,e] = np.round(x[:,e].astype('float')).astype('int')
                 elif r == 'floor':
-                    x[:,e] = np.floor(x[:,e])
+                    x[:,e] = np.floor(x[:,e].astype('float')).astype('int')
                 elif r == 'ceil':
-                    x[:,e] = np.ceil(x[:,e])
+                    x[:,e] = np.ceil(x[:,e].astype('float')).astype('int')
 
         # add x0
         if x0 is not None:

--- a/tests/command_line_tests.py
+++ b/tests/command_line_tests.py
@@ -258,6 +258,14 @@ def define_tests():
             "spellbook make-samples ; rm samples.npy",
             ReturnCodeCond(),
         ),
+        "spellbook make-samples -n 6 -dims 4 -round [False, round, floor, ceil]" : (
+            "spellbook make-samples -n 6 -dims 4 -round [False, round, floor, ceil]",
+            ReturnCodeCond()
+        ),
+        "spellbook make-samples -n 6 -dims 4 -repeat [5, -1]" : (
+            "spellbook make-samples -n 6 -dims 4 -repeat [5, -1]",
+            ReturnCodeCond()
+        ),
         # "spellbook learn": ("spellbook learn", ReturnCodeCond()),
         # "spellbook predict": ("spellbook predict", ReturnCodeCond()),
         # "spellbook collect": ("spellbook collect", ReturnCodeCond()),

--- a/tests/command_line_tests.py
+++ b/tests/command_line_tests.py
@@ -259,11 +259,11 @@ def define_tests():
             ReturnCodeCond(),
         ),
         "spellbook make-samples -n 6 -dims 4 -round [False, round, floor, ceil]" : (
-            "spellbook make-samples -n 6 -dims 4 -round [False, round, floor, ceil]",
+            "spellbook make-samples -n 6 -dims 4 -round [False, round, floor, ceil]; rm samples.npy",
             ReturnCodeCond()
         ),
         "spellbook make-samples -n 6 -dims 4 -repeat [5, -1]" : (
-            "spellbook make-samples -n 6 -dims 4 -repeat [5, -1]",
+            "spellbook make-samples -n 6 -dims 4 -repeat [5, -1]; rm samples.npy",
             ReturnCodeCond()
         ),
         # "spellbook learn": ("spellbook learn", ReturnCodeCond()),


### PR DESCRIPTION
Currently the generated samples appear to be floats. This will allow the option to round the samples with the specified options and is able to round on a per column basis.